### PR TITLE
update: Add Docker components to start in microservices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:18-alpine
+
+WORKDIR /usr/src/app
+
+COPY . ./
+
+RUN corepack enable
+
+RUN yarn cache clean && yarn install 
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["yarn", "dev"]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Node version: 18
     yarn dev or yarn start or gatsby develop // http://localhost:8000/
 ```
 
+## Start with Docker
+
+Node version: 18
+
+```bash
+    docker-compose up --build
+```
+
 ## Tecnologies
 
 - [ReactJS](https://pt-br.reactjs.org/);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    environment:
+      - NODE_ENV=development
+    volumes:
+      - .:/usr/src/app  # Mounts project code as volume
+      - /usr/src/app/node_modules  # Avoid conflicts with host node_modules
+    command: yarn dev #yarn dev or yarn start or gatsby develop

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby clean && gatsby build",
-    "develop": "gatsby develop",
+    "develop": "gatsby develop -H 0.0.0.0",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
     "dev": "npm run develop",


### PR DESCRIPTION
feat: adds Docker and Docker Compose for development environment

- Adds Dockerfile with support for Yarn 4 and Node 18 for compatibility with the project
- Configures docker-compose.yml to facilitate development with Gatsby
- Exposes port 8000 for external access
- Adds volumes to allow live hot reloading
- Sets NODE_ENV to development
- Updates package.json so that Gatsby listens on 0.0.0.0, allowing external connections

These additions make it easier to set up the development environment and run the project in containers.

![Docker](https://github.com/user-attachments/assets/e80ab66b-62d6-42ae-a445-7b74f0e613aa)
